### PR TITLE
Enhance GitHub commit and push process by adding rebase step and updating branch reference in push command

### DIFF
--- a/orb/src/commands/github-commit-and-push-changes.yml
+++ b/orb/src/commands/github-commit-and-push-changes.yml
@@ -65,15 +65,25 @@ steps:
         git config --global user.email "${USER_EMAIL}"
 
 
-        cd "<< parameters.folder >>"
-        # Fetch latest changes
-        git fetch origin "<< parameters.branch >>"
-
-        # Attempt to rebase on top of latest changes
-        git rebase "origin/<< parameters.branch >>"
-
+        # Stage changes first
         git add . -n  # Dry run to show what would be added
         git add .
+
+        # Create commit if there are changes
+        if git diff --staged --quiet; then
+          echo "No changes to commit"
+          exit 0
+        fi
+
+        echo "Committing changes..."
+        git commit -m "Update - Gov Uploads"
+
+        # Now fetch and rebase
+        echo "Fetching latest changes..."
+        git fetch origin ${CIRCLE_BRANCH}
+
+        echo "Rebasing on latest changes..."
+        git rebase origin/${CIRCLE_BRANCH}
 
 
         SKIP_CI=""

--- a/orb/src/commands/github-commit-and-push-changes.yml
+++ b/orb/src/commands/github-commit-and-push-changes.yml
@@ -64,10 +64,17 @@ steps:
         git config --global user.name "${USERNAME}"
         git config --global user.email "${USER_EMAIL}"
 
+
         cd "<< parameters.folder >>"
-        echo "adding new changes"
-        git add . -n
+        # Fetch latest changes
+        git fetch origin "<< parameters.branch >>"
+
+        # Attempt to rebase on top of latest changes
+        git rebase "origin/<< parameters.branch >>"
+
+        git add . -n  # Dry run to show what would be added
         git add .
+
 
         SKIP_CI=""
         if [ "<< parameters.skip-ci >>" = true ]; then
@@ -79,5 +86,5 @@ steps:
           echo "No changes to commit"
         else
           git commit -m "${SKIP_CI}<< parameters.commit-message >>"
-          git push "https://x-access-token:${<<parameters.github-token>>}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git" ${CIRCLE_BRANCH}
+          git push "https://x-access-token:${<<parameters.github-token>>}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git" "<< parameters.branch >>"
         fi

--- a/orb/src/commands/github-commit-and-push-changes.yml
+++ b/orb/src/commands/github-commit-and-push-changes.yml
@@ -15,7 +15,7 @@ parameters:
     description: "Branch where to commit to"
   folder:
     type: string
-    description:
+    description: "Folder to commit"
   commit-message:
     type: string
     description: "Message to use"
@@ -64,6 +64,7 @@ steps:
         git config --global user.name "${USERNAME}"
         git config --global user.email "${USER_EMAIL}"
 
+        cd "<< parameters.folder >>"
 
         # Stage changes first
         git add . -n  # Dry run to show what would be added


### PR DESCRIPTION

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request includes changes to the `orb/src/commands/github-commit-and-push-changes.yml` file to improve the process of committing and pushing changes to GitHub. The most important changes include adding a step to fetch and rebase on the latest changes from the remote branch and modifying the push command to use the specified branch parameter.

Enhancements to commit and push process:

* Added steps to fetch the latest changes from the remote branch and rebase on top of them before adding new changes. (`orb/src/commands/github-commit-and-push-changes.yml`)
* Modified the push command to use the specified branch parameter instead of the default branch. (`orb/src/commands/github-commit-and-push-changes.yml`)

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
