### PR TITLE
fix: renaming init-mise to checkout-with-mise

### DIFF
--- a/orb/src/commands/checkout-with-mise.yml
+++ b/orb/src/commands/checkout-with-mise.yml
@@ -1,5 +1,5 @@
 description: >
-  Initialize the mise environment.
+  Checkout then initialize the mise environment.
 steps:
   - checkout
   - run:


### PR DESCRIPTION
Renaming init-mise to be more descriptive to include the checkout command. 