### PR TITLE
feat: Add branch checkout parameter to mise command

### DIFF
--- a/orb/src/commands/checkout-with-mise.yml
+++ b/orb/src/commands/checkout-with-mise.yml
@@ -1,10 +1,18 @@
 description: >
   Checkout then initialize the mise environment.
+parameters:
+  checkout-branch:
+    type: string
+    default: "$CIRCLE_BRANCH"
 steps:
   - checkout
   - run:
       name: Initialize mise environment
       command: |
+        if [[ "$checkout-branch" != "$CIRCLE_BRANCH" ]]; then
+          git checkout "$checkout-branch"
+        fi
+
         # This is used to create a per-user cache key to preserve permissions across different
         # executor types.
         user=$(whoami)


### PR DESCRIPTION
Allow specifying a custom branch to checkout during the mise environment initialization, providing more flexibility in CI workflows

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request introduces a new parameter to the `checkout-with-mise.yml` file to allow specifying a branch to checkout before initializing the mise environment.

Key change:

* [`orb/src/commands/checkout-with-mise.yml`](diffhunk://#diff-c147b3b687068eda5cc5357afdf7011156803e66b2e6244be6de1091cc942d6bR3-R15): Added a `checkout-branch` parameter with a default value of `$CIRCLE_BRANCH` and a conditional step to checkout the specified branch if it differs from `$CIRCLE_BRANCH`.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
