### PR TITLE
Fix mise installer script include

### DIFF
--- a/orb/src/commands/checkout-with-mise.yml
+++ b/orb/src/commands/checkout-with-mise.yml
@@ -46,13 +46,10 @@ steps:
         - mise-v5-{{ checksum ".executor-user" }}-{{ checksum "mise.toml" }}
   - run:
       name: Install mise
+      command: <<include(scripts/install_mise.sh)>>
+  - run:
+      name: Configure mise environment
       command: |
-        if command -v mise &> /dev/null; then
-          echo "mise already installed at $(command -v mise)"
-        else
-          sh <<include(scripts/install_mise.sh)>>
-        fi
-
         echo "export PATH=\"$HOME/.local/bin:\$PATH\"" >> "$BASH_ENV"
         echo "export MISE_DATA_DIR=/data/mise-data" >> "$BASH_ENV"
         echo "export MISE_JOBS=$(nproc)" >> "$BASH_ENV"

--- a/orb/src/scripts/install_mise.sh
+++ b/orb/src/scripts/install_mise.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -eu
 
+if command -v mise; then
+    echo "mise already installed at $(command -v mise)"
+    exit 0
+fi
+
 #region logging setup
 if [ "${MISE_DEBUG-}" = "true" ] || [ "${MISE_DEBUG-}" = "1" ]; then
   debug() {


### PR DESCRIPTION
Addresses some limitations of the `include` directive so that the orb works correctly.
An `include()` script executed by a `command` step must only contain the `include()` script and nothing else. So the `Install mise` step is broken up to export the PATH, MISE_DATA_DIR, etc, in a separate step.

This limitation also prevents if statements in the `command`. So the check for a pre-installed `mise` binary is now handled by the installer script. Unfortunately, conditional steps (via `when` directives) aren't a solution as they cannot depend on runtime information.

Testing was done on a [monorepo main workflow](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/83902/workflows/98e46072-9f5f-4e1a-bf4f-771c317d8774) run using an updated orb with this change.