### PR TITLE
feat: Add GitHub event handler setup command

### DIFF
--- a/orb/src/commands/github-event-handler-setup.yml
+++ b/orb/src/commands/github-event-handler-setup.yml
@@ -1,0 +1,25 @@
+    description: "Create environment variables from the github event"
+    parameters:
+      env_prefix:
+        type: string
+        default: "github_"
+        description: "The prefix for the environment variables"
+      github_event_base64:
+        type: string
+        description: "The base64 encoded github event"
+    steps:
+      - run:
+          name: create environment variables from json
+          command: |
+            GITHUB_EVENT_JSON=$(echo $github_event_base64 | base64 --decode)
+            # Decode the base64 json
+            echo "export ${env_prefix}json_event='$GITHUB_EVENT_JSON'" >> $BASH_ENV
+            # Create environment variables from the json
+            while IFS='=' read -r key value; do
+                # Remove any quotes around the value and escape single quotes
+                value=$(printf '%s' "$value" | sed 's/["\047]//g')
+                echo "export '${env_prefix}$key'='$value'" >> $BASH_ENV
+            done < <(jq -r 'to_entries | .[] | .key + "=" + (.value|tostring)'\<<< "$GITHUB_EVENT_JSON")
+          environment:
+            env_prefix: << parameters.env_prefix >>
+            github_event_base64: << parameters.github_event_base64 >>

--- a/orb/src/commands/github-event-handler-setup.yml
+++ b/orb/src/commands/github-event-handler-setup.yml
@@ -1,25 +1,39 @@
-    description: "Create environment variables from the github event"
-    parameters:
-      env_prefix:
-        type: string
-        default: "github_"
-        description: "The prefix for the environment variables"
-      github_event_base64:
-        type: string
-        description: "The base64 encoded github event"
-    steps:
-      - run:
-          name: create environment variables from json
-          command: |
-            GITHUB_EVENT_JSON=$(echo $github_event_base64 | base64 --decode)
-            # Decode the base64 json
-            echo "export ${env_prefix}json_event='$GITHUB_EVENT_JSON'" >> $BASH_ENV
-            # Create environment variables from the json
-            while IFS='=' read -r key value; do
-                # Remove any quotes around the value and escape single quotes
-                value=$(printf '%s' "$value" | sed 's/["\047]//g')
-                echo "export '${env_prefix}$key'='$value'" >> $BASH_ENV
-            done < <(jq -r 'to_entries | .[] | .key + "=" + (.value|tostring)'\<<< "$GITHUB_EVENT_JSON")
-          environment:
-            env_prefix: << parameters.env_prefix >>
-            github_event_base64: << parameters.github_event_base64 >>
+description: "Create environment variables from the GitHub event"
+parameters:
+  env_prefix:
+    type: string
+    default: "github_"
+    description: "The prefix for the environment variables"
+  github_event_base64:
+    type: string
+    description: "The base64 encoded GitHub event"
+steps:
+  - run:
+      name: Create environment variables from JSON
+      shell: /bin/sh
+      command: |
+        # Decode and validate the base64 input
+        GITHUB_EVENT_JSON=$(echo "$github_event_base64" | base64 --decode 2>/dev/null)
+        echo "$GITHUB_EVENT_JSON" | jq -e . >/dev/null || {
+          echo "Invalid JSON payload."
+          exit 1
+        }
+
+        # Safe escaping function
+        escape_for_shell() {
+          printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+        }
+
+        # Export full JSON as a single safe variable
+        ESCAPED_JSON=$(escape_for_shell "$GITHUB_EVENT_JSON")
+        echo "export ${env_prefix}json_event=$ESCAPED_JSON" >> "$BASH_ENV"
+
+        # Export each field safely
+        echo "$GITHUB_EVENT_JSON" | jq -r 'to_entries[] | "\(.key)=\(.value|tostring)"' | while IFS='=' read -r key value; do
+          [ -z "$key" ] && continue
+          escaped_value=$(escape_for_shell "$value")
+          echo "export ${env_prefix}${key}=$escaped_value" >> "$BASH_ENV"
+        done
+      environment:
+        env_prefix: << parameters.env_prefix >>
+        github_event_base64: << parameters.github_event_base64 >>


### PR DESCRIPTION
Introduce a new command to create environment variables from GitHub event data. This command decodes the base64 encoded GitHub event and exports the relevant variables with a specified prefix, enhancing CI workflow integration.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request introduces a new command for setting up GitHub event handlers by creating environment variables from a base64 encoded GitHub event. The key changes are as follows:

* [`orb/src/commands/github-event-handler-setup.yml`](diffhunk://#diff-d60e0073fb4efcaaddb1db3e701a2859244452de10adb8e8e3311abb17207d16R1-R25): Added a new command to decode a base64 encoded GitHub event and create environment variables with a specified prefix. This includes parameters for the environment variable prefix and the base64 encoded event, as well as steps to decode the event and generate environment variables.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
