### PR TITLE
feat: Add submodule checkout

### DIFF
--- a/orb/src/commands/checkout-with-mise.yml
+++ b/orb/src/commands/checkout-with-mise.yml
@@ -17,7 +17,7 @@ steps:
             name: Initialize and Update Submodules
             command: |
               git submodule sync --recursive
-              git submodule update --init --recursive
+              git submodule update --init --recursive --depth 1
   - run:
       name: Initialize mise environment
       command: |

--- a/orb/src/commands/checkout-with-mise.yml
+++ b/orb/src/commands/checkout-with-mise.yml
@@ -16,7 +16,6 @@ steps:
         - run:
             name: Initialize and Update Submodules
             command: |
-              git submodule sync --recursive
               git submodule update --init --recursive --depth 1
   - run:
       name: Initialize mise environment

--- a/orb/src/commands/checkout-with-mise.yml
+++ b/orb/src/commands/checkout-with-mise.yml
@@ -4,8 +4,20 @@ parameters:
   checkout-branch:
     type: string
     default: "$CIRCLE_BRANCH"
+  submodules:
+    type: boolean
+    default: false
+    description: Whether to initialize and update git submodules recursively
 steps:
   - checkout
+  - when:
+      condition: << parameters.submodules >>
+      steps:
+        - run:
+            name: Initialize and Update Submodules
+            command: |
+              git submodule sync --recursive
+              git submodule update --init --recursive
   - run:
       name: Initialize mise environment
       command: |


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds a `submodules` parameter to the `checkout-with-mise` command. The default value matches the existing command behavior and the submodule checkout needs to be enabled by setting `submodules: true`.

Related to https://github.com/ethereum-optimism/optimism/issues/16975