### PR TITLE
chore: Prepare for blobless checkouts

### DIFF
--- a/orb/src/commands/checkout-with-mise.yml
+++ b/orb/src/commands/checkout-with-mise.yml
@@ -4,6 +4,13 @@ parameters:
   checkout-branch:
     type: string
     default: "$CIRCLE_BRANCH"
+  checkout-method:
+    type: enum
+    enum:
+      - blobless
+      - full
+    default: full
 steps:
-  - checkout
+  - checkout:
+      method: << parameters.checkout-method >>
   - install-mise

--- a/orb/src/commands/checkout-with-mise.yml
+++ b/orb/src/commands/checkout-with-mise.yml
@@ -1,9 +1,6 @@
 description: >
   Checkout then initialize the mise environment.
 parameters:
-  checkout-branch:
-    type: string
-    default: "$CIRCLE_BRANCH"
   checkout-method:
     type: enum
     enum:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

CircleCI will [switch all checkouts to blobless on November 3rd](https://circleci.com/changelog/default-method-used-to-checkout-code-from-your-repository-is-changing-on-nov/). This change prepares us for a painless rollout by keeping the default checkout method as `full` (the current default) so we can roll it out without any hassle.

Additionally, [unused `checkout-branch` parameter](https://github.com/search?q=org%3Aethereum-optimism%20checkout-branch&type=code) has been removed.