### PR TITLE
fix(mise): auto retries

### DIFF
--- a/orb/src/commands/install-mise.yml
+++ b/orb/src/commands/install-mise.yml
@@ -39,6 +39,8 @@ steps:
         fi
   - run:
       name: Install mise
+      max_auto_reruns: 3  # allow 3 retries in case of transient errors
+      auto_rerun_delay: 3s
       command: <<include(scripts/install_mise.sh)>>
   - run:
       name: Copy mise for cache


### PR DESCRIPTION
Enable automatic retries of the step to install mise, which sometimes fails due to intermittent networking errors.