### PR TITLE
feat(mise): cache & retries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,22 @@ This keeps the repository tags synchronized with the orb versions.
 8. **Plan ahead for production releases** - If you're not a GitHub org owner, coordinate with #eng-oncall in Slack before you need to publish
 9. **Test thoroughly** - Since only owners can publish production, make sure your dev version is thoroughly tested to avoid multiple release cycles
 
+## checkout-with-mise cache + retry
+
+- Optional caching around `mise install -y`/ubi (set `enable-mise-cache: true`) saves/restores `~/.local/share/mise`, `~/.cache/mise`, `~/.cache/ubi`.
+- Cache key params: `mise-cache-key-prefix` (default `mise-cache`) and `mise-cache-checksum` (default `{{ checksum "mise.toml" }}`; set to any checksum expression or value to combine multiple configs or break the cache).
+- Install step retries with backoff (0s, 15s, 45s, 90s) to ride out GitHub 403 rate limits before failing.
+- Defaults keep previous behavior; enable caching explicitly per job.
+
+Example:
+```yaml
+- utils/checkout-with-mise:
+    checkout-method: full
+    enable-mise-cache: true
+    mise-cache-key-prefix: op-mise
+    mise-cache-checksum: '{{ checksum "config/mise.toml" }}'
+```
+
 ## Troubleshooting
 
 ### "User does not have access to publish SemVer orbs in this namespace"

--- a/orb/src/commands/checkout-with-mise.yml
+++ b/orb/src/commands/checkout-with-mise.yml
@@ -7,7 +7,19 @@ parameters:
       - blobless
       - full
     default: full
+  enable-mise-cache:
+    type: boolean
+    default: false
+  mise-cache-key-prefix:
+    type: string
+    default: "mise-cache"
+  mise-cache-checksum:
+    type: string
+    default: '{{ checksum "mise.toml" }}'
 steps:
   - checkout:
       method: << parameters.checkout-method >>
-  - install-mise
+  - install-mise:
+      enable_mise_cache: << parameters.enable-mise-cache >>
+      mise_cache_key_prefix: << parameters.mise-cache-key-prefix >>
+      mise_cache_checksum: << parameters.mise-cache-checksum >>

--- a/orb/src/commands/install-mise.yml
+++ b/orb/src/commands/install-mise.yml
@@ -4,6 +4,15 @@ parameters:
   mise_config:
     type: string
     default: "mise.toml"
+  enable_mise_cache:
+    type: boolean
+    default: false
+  mise_cache_key_prefix:
+    type: string
+    default: "mise-cache"
+  mise_cache_checksum:
+    type: string
+    default: '{{ checksum "mise.toml" }}'
 steps:
   - run:
       name: Initialize mise environment
@@ -56,11 +65,50 @@ steps:
         # install rust artifacts where they'll be cached
         echo "export MISE_CARGO_HOME=\${MISE_DATA_DIR}/.cargo" >> "$BASH_ENV"
         echo "export MISE_RUSTUP_HOME=\${MISE_DATA_DIR}/.rustup" >> "$BASH_ENV"
+  - when:
+      condition: << parameters.enable_mise_cache >>
+      steps:
+        - restore_cache:
+            name: Restore mise/ubi install cache
+            keys:
+              - << parameters.mise_cache_key_prefix >>-{{ checksum ".executor-user" }}-<< parameters.mise_cache_checksum >>
+              - << parameters.mise_cache_key_prefix >>-{{ checksum ".executor-user" }}
   - run:
-      name: Install mise deps
+      name: Install mise deps (with retry)
       command: |
         # Install mise data to a common location between each executor type.
-        mise install -v -y
+        set -euo pipefail
+
+        backoffs="0 15 45 90"
+        attempt=1
+        for delay in $backoffs; do
+          if [ "$delay" -gt 0 ]; then
+            echo "Retry ${attempt}: sleeping ${delay}s before running mise install -y..."
+            sleep "$delay"
+          fi
+
+          if mise install -v -y; then
+            echo "mise install completed successfully on attempt ${attempt}."
+            exit 0
+          fi
+
+          status=$?
+          echo "mise install failed with exit code ${status} on attempt ${attempt}."
+          attempt=$((attempt + 1))
+        done
+
+        echo "mise install failed after $((attempt - 1)) attempts (backoffs: ${backoffs})."
+        exit 1
+  - when:
+      condition: << parameters.enable_mise_cache >>
+      steps:
+        - save_cache:
+            name: Save mise/ubi install cache
+            key: << parameters.mise_cache_key_prefix >>-{{ checksum ".executor-user" }}-<< parameters.mise_cache_checksum >>
+            paths:
+              - ~/.local/share/mise
+              - ~/.cache/mise
+              - ~/.cache/ubi
   - save_cache:
       name: Save mise cache
       key: mise-v8-{{ checksum ".executor-user" }}-{{ checksum "<< parameters.mise_config >>" }}


### PR DESCRIPTION
## Description

Adds a cache and retries for mise dependencies to assist with Github rate limits. ([Example CI failure](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/110106/workflows/c88d5a2e-3d24-4638-afd5-25bcdb37445e/jobs/4185606/parallel-runs/1?filterBy=FAILED))

## Testing
Tested in optimism monorepo:
- branch: sc/mise-cache-and-retries
- ci pipeline: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/110142
