### PR TITLE
add gate conditional force approval

### DIFF
--- a/orb/src/commands/ci-gate.yml
+++ b/orb/src/commands/ci-gate.yml
@@ -1,15 +1,26 @@
 description: >
-  "Verify all required jobs passed by checking ci-gate's dependencies via the CircleCI API."
+  Verify all required jobs passed by checking ci-gate's dependencies via the CircleCI API.
+  With always-succeed, the check is skipped and the step exits successfully.
 parameters:
   circleci-api-token:
     type: env_var_name
     description: "Name of the environment variable holding the CircleCI API token"
     default: "CIRCLE_API_TOKEN"
+  always-succeed:
+    type: boolean
+    default: false
+    description: >
+      When true, skip the dependency check and exit successfully (no API token required).
 steps:
   - run:
       name: Verify all required jobs passed
       command: |
         set -euo pipefail
+
+        if [ "<< parameters.always-succeed >>" = "true" ]; then
+          echo "Skipping ci-gate: always-succeed is true."
+          exit 0
+        fi
 
         if [ -z "${<< parameters.circleci-api-token >>:-}" ]; then
           echo "ERROR: << parameters.circleci-api-token >> is not set"


### PR DESCRIPTION
This pull request updates the `ci-gate` command in the CircleCI orb to add an option for skipping the dependency check. The main change is the introduction of a new `always-succeed` parameter, which allows users to bypass the dependency verification step and exit successfully, even if required jobs have not been checked.

**Enhancement to CI workflow:**

* Added a new boolean parameter `always-succeed` to the `ci-gate` command in `ci-gate.yml`. When set to `true`, this skips the dependency check and exits the step successfully, removing the requirement for a CircleCI API token in this scenario.
* Updated the step description to reflect the new behavior and documented the `always-succeed` parameter for clarity.